### PR TITLE
Switch unmaintained parsemail dep to the active fork

### DIFF
--- a/email/smtpmail/smtp.go
+++ b/email/smtpmail/smtp.go
@@ -7,9 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"mime/quotedprintable"
-
-	"github.com/DusanKasan/parsemail"
+	"github.com/k3a/parsemail"
 	"github.com/emersion/go-smtp"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -148,16 +146,6 @@ func (h *handler) handleMessage(from string, parsedEmail parsemail.Email) error 
 	partialMsg.BodyPlain = strings.TrimSpace(parsedEmail.TextBody)
 
 	if parsedEmail.HTMLBody != "" {
-		if strings.ToLower(parsedEmail.Header.Get("Content-Transfer-Encoding")) == "quoted-printable" {
-			unquoted, err := io.ReadAll(quotedprintable.NewReader(strings.NewReader(parsedEmail.HTMLBody)))
-			if err != nil {
-				log.WithError(err).Error("SMTP: failed to decode quoted printable")
-				return err
-			}
-
-			parsedEmail.HTMLBody = string(unquoted)
-		}
-
 		modifiedHTML, err := email.AddTargetBlank(strings.TrimSpace(parsedEmail.HTMLBody))
 		if err != nil {
 			log.WithError(err).Error("SMTP: failed to AddTargetBlank")

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/haydenwoodhead/burner.kiwi
 go 1.17
 
 require (
-	github.com/DusanKasan/parsemail v1.2.0
 	github.com/PuerkitoBio/goquery v1.5.0
 	github.com/aws/aws-sdk-go v1.34.0
 	github.com/emersion/go-smtp v0.15.0
@@ -14,6 +13,7 @@ require (
 	github.com/haydenwoodhead/gateway v1.2.1
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da
+	github.com/k3a/parsemail v1.3.0
 	github.com/lib/pq v1.2.0
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/ory/dockertest v3.3.5+incompatible

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOEl
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DusanKasan/parsemail v1.2.0 h1:CrzTL1nuPLxB41aO4zE/Tzc9GVD8jjifUftlbTKQQl4=
-github.com/DusanKasan/parsemail v1.2.0/go.mod h1:B9lfMbpVe4DMqPImAOCGti7KEwasnRTrKKn66iQefVs=
 github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
@@ -232,6 +230,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da h1:5y58+OCjoHCYB8182mpf/dEsq0vwTKPOo4zGfH0xW9A=
 github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da/go.mod h1:oLH0CmIaxCGXD67VKGR5AacGXZSMznlmeqM8RzPrcY8=
+github.com/k3a/parsemail v1.3.0 h1:HKEV55Of9k3STFEx8pclovZOY4I+EEXr9dPv5y5NCuo=
+github.com/k3a/parsemail v1.3.0/go.mod h1:1cbjov/2l6NjwuE2t0C52dT9g7yHzeN2n6P/PXvYE2c=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
The original parsemail golang library is unmaintained so I've made a fork and plan to actively manage it.
This fork integrates several pending PRs from the original repo and properly handles various Content-Transfer-Encoding like base64, which previously displayed as base64-encoded text in burner.kiwi

It is a drop-in replacement with just "quoted-printable" parsing removed as that is now done in the parsemail library directly.

Fixes #48 