### PR TITLE
Fix parsing sliceVar when it is an empty string

### DIFF
--- a/config.go
+++ b/config.go
@@ -85,6 +85,9 @@ func mustParseStringVar(key string) (v string) {
 
 func parseSliceVar(key string) (v []string) {
 	val := parseStringVar(key)
+	if len(val) == 0 {
+		return
+	}
 	split := strings.Split(val, ",")
 
 	for _, s := range split {


### PR DESCRIPTION
Parsing an empty string into a slice variable should result in an empty slice instead of a slice with a single "" string. The bug caused all email to be rejected due to abuse protection when no BLACKLIST was configured (environment variable being an empty string).